### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,6 +2,8 @@
 # For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
 
 name: Go
+permissions:
+  contents: read
 
 on:
   push:


### PR DESCRIPTION
Potential fix for [https://github.com/rwbm/morondanga/security/code-scanning/1](https://github.com/rwbm/morondanga/security/code-scanning/1)

To fix the problem, add a `permissions` block that limits the GITHUB_TOKEN to the minimal required for this workflow. Since the workflow solely checks out code and builds/tests it, it only needs `contents: read` permission. Insert the following just after the `name: Go` declaration (line 4), or directly under `jobs.build` (line 14). The best practice is to apply basic permissions at the workflow level unless jobs require different settings. Therefore, insert:

```yaml
permissions:
  contents: read
```

under the workflow name, before the `on:` trigger.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
