### PR TITLE
feat: emit process.memory.usage and Go runtime metrics via OTEL

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -64,6 +64,7 @@ require (
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	go.opentelemetry.io/auto/sdk v1.2.1 // indirect
+	go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.43.0 // indirect
 	go.opentelemetry.io/proto/otlp v1.10.0 // indirect
 	go.uber.org/multierr v1.11.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -104,6 +104,8 @@ go.opentelemetry.io/contrib/bridges/otelzap v0.18.0 h1:EkWTww6Nqs2P29r01NeuNsG7q
 go.opentelemetry.io/contrib/bridges/otelzap v0.18.0/go.mod h1:lj3bgA/c7nJy0NhxqyvWJFC30aTgB+G0RKDdLbvJ4QM=
 go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.68.0 h1:7N94HrYgVc2tng6xEjmbycupxteYLll7lPlEi/UK5ok=
 go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho v0.68.0/go.mod h1:1i+7wBOfx0kn7PSGRKZ8e7zIhs+AmvLCiCloySDUeck=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0 h1:jhVIQEprwUTV+KfzzliLidclhoTOoHTgdz96kAyR8mU=
+go.opentelemetry.io/contrib/instrumentation/runtime v0.68.0/go.mod h1:4HsdbLUbernaTnA8CNaNE+1g026SciXb3juRYe3l8EY=
 go.opentelemetry.io/contrib/propagators/b3 v1.43.0 h1:CETqV3QLLPTy5yNrqyMr41VnAOOD4lsRved7n4QG00A=
 go.opentelemetry.io/contrib/propagators/b3 v1.43.0/go.mod h1:Q4mCiCdziYzpNR0g+6UqVotAlCDZdzz6L8jwY4knOrw=
 go.opentelemetry.io/otel v1.43.0 h1:mYIM03dnh5zfN7HautFE4ieIig9amkNANT+xcVxAj9I=

--- a/observability.go
+++ b/observability.go
@@ -3,13 +3,16 @@ package morondanga
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"time"
 
+	runtimemetrics "go.opentelemetry.io/contrib/instrumentation/runtime"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/exporters/otlp/otlplog/otlploghttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetrichttp"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracehttp"
 	"go.opentelemetry.io/otel/log/global"
+	"go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/propagation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
@@ -107,6 +110,22 @@ func (s *Service) initObservability() error {
 		sdklog.WithResource(res),
 	)
 	global.SetLoggerProvider(lp)
+
+	// Go runtime metrics (goroutines, GC, etc.) via contrib package.
+	_ = runtimemetrics.Start(runtimemetrics.WithMinimumReadMemStatsInterval(30 * time.Second))
+
+	// process.memory.usage — standard OTLP semconv, backed by runtime.MemStats.Sys.
+	meter := mp.Meter(s.Configuration().GetApp().Name)
+	memGauge, _ := meter.Int64ObservableGauge("process.memory.usage",
+		metric.WithUnit("By"),
+		metric.WithDescription("Process virtual memory reserved from the OS"),
+	)
+	_, _ = meter.RegisterCallback(func(_ context.Context, o metric.Observer) error {
+		var ms runtime.MemStats
+		runtime.ReadMemStats(&ms)
+		o.ObserveInt64(memGauge, int64(ms.Sys))
+		return nil
+	}, memGauge)
 
 	s.tracer = otel.Tracer(s.Configuration().GetApp().Name)
 	s.otelShutdown = func() {


### PR DESCRIPTION
## Summary

- Adds `go.opentelemetry.io/contrib/instrumentation/runtime` which auto-emits Go runtime metrics: `go.memory.used`, `go.goroutine.count`, `go.processor.limit`, `go.memory.allocated`, etc.
- Adds a custom `process.memory.usage` gauge backed by `runtime.MemStats.Sys` — emits standard OTLP semconv naming so Loggero's APM memory panel picks it up automatically
- Both metrics export every 30 seconds via the existing periodic OTLP reader

## Test plan

- [ ] Deploy a service using the updated morondanga version
- [ ] Verify `process.memory.usage` appears in Loggero APM → Memory Usage panel
- [ ] Verify Go runtime metrics (`go.memory.used`, `go.goroutine.count`) are visible in Loggero Metrics explorer

🤖 Generated with [Claude Code](https://claude.com/claude-code)