### PR TITLE
fix: eliminate inflated request counts and add path exclusion for metrics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -90,6 +90,9 @@ type (
 		// ApiKey is sent as X-API-Key on every OTLP export request.
 		// Required when the collector enforces API key authentication.
 		ApiKey string
+		// ExcludedPaths lists URL paths that should be excluded from tracing
+		// and metrics (e.g. ["/health", "/metrics"]). Exact prefix match.
+		ExcludedPaths []string
 	}
 )
 

--- a/observability.go
+++ b/observability.go
@@ -16,6 +16,7 @@ import (
 	"go.opentelemetry.io/otel/propagation"
 	sdklog "go.opentelemetry.io/otel/sdk/log"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
+	"go.opentelemetry.io/otel/sdk/metric/metricdata"
 	"go.opentelemetry.io/otel/sdk/resource"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	semconv "go.opentelemetry.io/otel/semconv/v1.26.0"
@@ -75,6 +76,11 @@ func (s *Service) initObservability() error {
 		otlpmetrichttp.WithEndpointURL(endpoint + "/v1/metrics"),
 		otlpmetrichttp.WithInsecure(),
 		otlpmetrichttp.WithTimeout(5 * time.Second),
+		// Force delta temporality so each export window contains only new observations.
+		// The SDK default is cumulative, which causes SUM(count) queries to compound.
+		otlpmetrichttp.WithTemporalitySelector(func(_ sdkmetric.InstrumentKind) metricdata.Temporality {
+			return metricdata.DeltaTemporality
+		}),
 	}
 	if obs.ApiKey != "" {
 		metricOpts = append(metricOpts, otlpmetrichttp.WithHeaders(map[string]string{"X-API-Key": obs.ApiKey}))

--- a/service_web.go
+++ b/service_web.go
@@ -13,9 +13,6 @@ import (
 	"github.com/rwbm/morondanga/common"
 	"github.com/rwbm/morondanga/middleware"
 	"go.opentelemetry.io/contrib/instrumentation/github.com/labstack/echo/otelecho"
-	"go.opentelemetry.io/otel"
-	"go.opentelemetry.io/otel/attribute"
-	otelmetric "go.opentelemetry.io/otel/metric"
 	"go.opentelemetry.io/otel/trace"
 	"go.uber.org/zap"
 )
@@ -112,8 +109,20 @@ func (s *Service) initWebServer() {
 	// otelecho must be registered before the request logger so the span is
 	// already in the context when we log latency + status.
 	if obs := s.Configuration().GetObservability(); obs != nil && obs.Enabled {
-		s.server.Use(otelecho.Middleware(s.Configuration().GetApp().Name))
-		s.server.Use(s.httpMetricsMiddleware())
+		var otelOpts []otelecho.Option
+		if len(obs.ExcludedPaths) > 0 {
+			excluded := obs.ExcludedPaths
+			otelOpts = append(otelOpts, otelecho.WithSkipper(func(c echo.Context) bool {
+				path := c.Request().URL.Path
+				for _, p := range excluded {
+					if strings.HasPrefix(path, p) {
+						return true
+					}
+				}
+				return false
+			}))
+		}
+		s.server.Use(otelecho.Middleware(s.Configuration().GetApp().Name, otelOpts...))
 	}
 	s.server.Use(s.httpRequestLogger())
 	if s.Configuration().GetHTTP().AddTraceID {
@@ -239,35 +248,6 @@ func (rc *responseCapture) Flush() {
 
 func (rc *responseCapture) bytes() []byte {
 	return rc.buf.Bytes()
-}
-
-// httpMetricsMiddleware records http.server.request.duration for every request.
-// The histogram is created once when the middleware is initialized and reused
-// across all requests, keeping the hot path allocation-free.
-func (s *Service) httpMetricsMiddleware() echo.MiddlewareFunc {
-	meter := otel.Meter(s.Configuration().GetApp().Name)
-	reqDuration, _ := meter.Float64Histogram(
-		"http.server.request.duration",
-		otelmetric.WithUnit("s"),
-		otelmetric.WithDescription("Duration of HTTP server requests."),
-		otelmetric.WithExplicitBucketBoundaries(
-			0.005, 0.01, 0.025, 0.05, 0.075, 0.1, 0.25, 0.5, 0.75, 1, 2.5, 5, 7.5, 10,
-		),
-	)
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			start := time.Now()
-			err := next(c)
-			reqDuration.Record(c.Request().Context(), time.Since(start).Seconds(),
-				otelmetric.WithAttributes(
-					attribute.String("http.request.method", c.Request().Method),
-					attribute.Int("http.response.status_code", c.Response().Status),
-					attribute.String("http.route", c.Path()),
-				),
-			)
-			return err
-		}
-	}
 }
 
 func (s *Service) setHealthCheck() {


### PR DESCRIPTION
## Summary

- **Remove duplicate metric instrument**: `httpMetricsMiddleware()` and `otelecho.Middleware` both emitted `http.server.request.duration`, creating 2 rows per export window and doubling all counts
- **Force delta temporality**: The Go OTel SDK default is cumulative for histograms — `SUM(count)` over any time range compounds running totals (observed ~32× inflation in prod). Delta ensures each export window contains only new observations
- **Add `ExcludedPaths` to `ObservabilityConfig`**: Paths listed here are skipped by otelecho's `WithSkipper`, so health checks and similar noise don't pollute APM data

## Config example

```yaml
observability:
  enabled: true
  endpoint: http://loggero:4318
  api_key: lk_...
  excluded_paths:
    - /health
    - /metrics
```

## Test plan

- [ ] Deploy a food-bot service with the new version and verify request counts in Loggero APM match expected rate (~1 req/10s for `/health`)
- [ ] Confirm `/health` no longer appears in APM service routes when listed in `excluded_paths`
- [ ] Verify `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)